### PR TITLE
Fix two minor issues

### DIFF
--- a/src/WakaTime.csproj
+++ b/src/WakaTime.csproj
@@ -58,14 +58,14 @@
     <AssemblyOriginatorKeyFile>Key.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="INIFileParser">
-      <HintPath>..\packages\ini-parser.2.2.4\lib\net20\INIFileParser.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.IO.Compression" />
     <Reference Include="System.IO.Compression.FileSystem" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Xml" />
+    <Reference Include="INIFileParser">
+      <HintPath>packages\ini-parser.2.2.4\lib\net20\INIFileParser.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="EditorInfo.cs" />

--- a/src/WakaTimeCli.cs
+++ b/src/WakaTimeCli.cs
@@ -89,7 +89,7 @@ namespace WakaTime
 
         static Version GetLatestWakaTimeCliVersion()
         {
-            var regex = new Regex(@"(__version_info__ = )(\(( ?\'[0-9]\'\,?){3}\))");
+            var regex = new Regex(@"(__version_info__ = )(\(( ?\'[0-9]+\'\,?){3}\))");
             var client = new WebClient
             {
                 Proxy = WakaTimeConfigFile.GetProxy()
@@ -103,7 +103,7 @@ namespace WakaTime
                 if (match.Success)
                 {
                     var groupVersion = match.Groups[2];
-                    var regexVersion = new Regex(@"\'(?<major>\d)\'\,\s?\'(?<minor>\d)\'\,\s?\'(?<build>\d)\'");
+                    var regexVersion = new Regex(@"\'(?<major>\d+)\'\,\s?\'(?<minor>\d+)\'\,\s?\'(?<build>\d+)\'");
                     var versionMatch = regexVersion.Match(groupVersion.Value);
                     return new Version(
                         int.Parse(versionMatch.Groups["major"].Value),


### PR DESCRIPTION
- deal with two digit version numbers, e.g. 4.1.10
- fix location of INIFileParser assembly in project file

This fixes the MonoDevelop addin.
